### PR TITLE
test: add concurrency test

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log"
 	"testing"
 	"time"
 
@@ -192,6 +193,94 @@ func TestNewCacheSubscriptionWithOptions(t *testing.T) {
 	})
 }
 
+func TestConcurrentRequestsForSameKey(t *testing.T) {
+	redisClient := redis.NewClient(&redis.Options{
+		Addr: ":6379",
+		DB:   0,
+	})
+
+	subscriptionTimeout := time.Second * 5
+	keyTTL := time.Second * 2
+	requestProcessingTime := 100 * time.Millisecond
+
+	response := Response{Result: true}
+
+	// First request
+	resourceKey := "data"
+	go func() {
+		cache := cache_lib.NewCache[Response](redisClient, &cache_lib.CacheOptions{
+			SubscriptionTimeout: subscriptionTimeout,
+			UnsubscribeAndClose: true,
+		})
+		data, err := cache.RememberBlocking(
+			context.Background(),
+			func(ctx context.Context) (*Response, error) {
+				log.Println("miss from 1")
+				time.Sleep(requestProcessingTime)
+				return &response, nil
+			},
+			func(ctx context.Context, data *Response) {
+				log.Println("hit from 1 request")
+			},
+			resourceKey,
+			keyTTL,
+		)
+		log.Println("first request finished", data, err)
+	}()
+
+	// Second request come with some delay. Key is existing but subscription missed event and stuck till subscriptionTimeout
+	time.Sleep(requestProcessingTime + time.Millisecond*1)
+
+	cache := cache_lib.NewCache[Response](redisClient, &cache_lib.CacheOptions{
+		SubscriptionTimeout: subscriptionTimeout,
+		UnsubscribeAndClose: true,
+	})
+	result, err := cache.RememberBlocking(context.Background(),
+		func(ctx context.Context) (*Response, error) {
+			log.Println("miss from 2")
+			time.Sleep(requestProcessingTime)
+			return &response, nil
+		},
+		func(ctx context.Context, data *Response) {
+			log.Println("hit from 2 request")
+		},
+		resourceKey,
+		keyTTL)
+	log.Println("second request finished", result, err)
+	assert.NoError(t, err)
+}
+
+func TestPublishBeforeSubscribe(t *testing.T) {
+	redisClient := redis.NewClient(&redis.Options{
+		Addr: ":6379",
+		DB:   0,
+	})
+	_, err := redisClient.Publish(context.Background(), "foo", "before subscribe").Result()
+	assert.NoError(t, err)
+
+	subscription := cache_lib.NewCacheSubscription(redisClient, "foo")
+	subscription.Subscribe(context.Background())
+	channel, err := subscription.GetChannel(context.Background())
+	assert.NoError(t, err)
+	// Subscription timeout
+	go func() {
+		time.Sleep(time.Second * 5)
+		_ = subscription.UnsubscribeAndClose(context.Background())
+	}()
+	go func() {
+		_, err := redisClient.Publish(context.Background(), "foo", "publish immediately").Result()
+		assert.NoError(t, err)
+	}()
+	go func() {
+		time.Sleep(time.Millisecond * 10)
+		_, err := redisClient.Publish(context.Background(), "foo", "after subscribe").Result()
+		assert.NoError(t, err)
+	}()
+	for msg := range channel {
+		log.Println(msg.Payload)
+	}
+
+}
 func TestCacheFailSet(t *testing.T) {
 	db, mock := redismock.NewClientMock()
 


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.
-->

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [ ] I have confirmed that the PR type is appropriate for the change I am making according to
  the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [ ] I have typed an adequate description that explains **why** I am making this change.
- [ ] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

* Redis subscriptions [have at-most-once semantic](https://redis.io/docs/latest/develop/interact/pubsub/#format-of-pushed-messages) and publishing event for topic that not have subscribers will lead to missing this event. TestPublishBeforeSubscribe cover this behaviour, we can see that "`before subscribe`" event (even "`publish immediately`" sometimes) not reached subscriber:
```
=== RUN   TestPublishBeforeSubscribe
2025/01/10 13:04:38 after subscribe
--- PASS: TestPublishBeforeSubscribe (5.01s)
PASS
```
```
=== RUN   TestPublishBeforeSubscribe
2025/01/10 13:07:20 publish immediately
2025/01/10 13:07:20 after subscribe
--- PASS: TestPublishBeforeSubscribe (5.01s)
PASS
```
* So cache-lib have bug, when concurrent requests might stuck waiting notification for event. Here is results of the TestConcurrentRequestsForSameKey runs, we can see that it not stable:
```
=== RUN   TestConcurrentRequestsForSameKey
2025/01/10 12:58:24 miss from 1
2025/01/10 12:58:25 first request finished &{true} <nil>
2025/01/10 12:58:30 second request finished <nil> error reading from pub/sub
    cache_test.go:250: 
        	Error Trace:	/Users/taras/projects/cache-lib-go/cache_test.go:250
        	Error:      	Received unexpected error:
        	            	error reading from pub/sub
        	Test:       	TestConcurrentRequestsForSameKey
--- FAIL: TestConcurrentRequestsForSameKey (5.11s)

FAIL
```
Another run might pass
```
=== RUN   TestConcurrentRequestsForSameKey
2025/01/10 13:01:58 miss from 1
2025/01/10 13:01:58 first request finished &{true} <nil>
2025/01/10 13:01:58 second request finished &{true} <nil>
--- PASS: TestConcurrentRequestsForSameKey (0.11s)
PASS
```
- fnx-api-gateway has ~100 errors per hour during peak time because of this bug - [grafana](https://grafana.honestbank.com/explore?panes=%7B%22yL5%22:%7B%22datasource%22:%22loki-prod%22,%22queries%22:%5B%7B%22refId%22:%22D%22,%22expr%22:%22%7Bapp%3D%5C%22fnx-api-gateway%5C%22%7D%20%7C~%20%60error%20reading%20from%20pub/sub%60%20%7C%3D%20%60couldn't%20get%20AccountEnquiry%20data%60%20%7C%20json%20%7C%20__error__%20!%3D%20%60JSONParserErr%60%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22loki-prod%22%7D,%22editorMode%22:%22builder%22,%22hide%22:false%7D%5D,%22range%22:%7B%22from%22:%22now-30d%22,%22to%22:%22now%22%7D%7D%7D&schemaVersion=1&orgId=11)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/cache-lib-go/8)
<!-- Reviewable:end -->
