### PR TITLE
feat: upgrade go version in cache lib go [SS-7546]

### DIFF
--- a/.github/workflows/trivy_scan.yaml
+++ b/.github/workflows/trivy_scan.yaml
@@ -9,7 +9,7 @@ jobs:
       - name: Set up Golang
         uses: actions/setup-go@v2
         with:
-          go-version: "1.18"
+          go-version: "1.26"
         id: go
 
       - name: Check out code into the Go module directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # DO NOT CHANGE. This file is being managed from a central repository
 # To know more simply visit https://github.com/honestbank/.github/blob/main/docs/about.md
 
-FROM golang:1.18 as builder
+FROM golang:1.26 AS builder
 WORKDIR /app
 COPY . .
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/honestbank/cache-lib-go
 
-go 1.24
+go 1.26
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5


### PR DESCRIPTION
Linear: https://linear.app/honestbank/issue/SS-7546

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to
  the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

Upgrade the Go version across the module and its build/scan tooling so the repo builds and is scanned on a supported toolchain. `build.yaml` was already on 1.26; the remaining references were stale.

* `go.mod` — bump the language version from `go 1.24` to `go 1.26`. No dependency changes; `go mod tidy` produced no churn.
* `Dockerfile` — bump the builder image from `golang:1.18` to `golang:1.26`. Required, not cosmetic: a 1.18 builder cannot compile a module declaring `go 1.26`. Also normalised `as builder` to `AS builder` to silence the BuildKit lowercase-keyword warning.
* `.github/workflows/trivy_scan.yaml` — bump `actions/setup-go` from `1.18` to `1.26` so the Trivy filesystem scan resolves modules on the same toolchain as the build.

Verified locally on go1.26.1: `go build ./...`, `go vet ./...` and `go test ./...` all pass.

**Note for reviewers:** `Dockerfile` carries a `DO NOT CHANGE. This file is being managed from a central repository` header pointing at [honestbank/.github](https://github.com/honestbank/.github/blob/main/docs/about.md). It is edited here because the Docker build is otherwise broken by the `go.mod` bump, but the central template likely needs the same bump to avoid this being reverted on the next sync.

No experiment because its just upgrading go version